### PR TITLE
fix: make the example test in the README compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func TestBootCurrentLinuxKernelInQemu(t *testing.T) {
 			"root=/dev/mapper/cryptroot",
 		},
 		Disks: []vmtest.QemuDisk{
-			{"testdata/luksv2.disk", "raw"},
+			{Path: "testdata/luksv2.disk", Format: "raw"},
 		},
 		Verbose: testing.Verbose(),
 		Timeout: 20 * time.Second,


### PR DESCRIPTION
Hello @anatol, very simple contribution :-)

I think that the first breakage has been added in b951d15 and then in afd7b1d.

Extracting the example in a file and then running the test:

    $ go test
    # github.com/anatol/vmtest/examples [github.com/anatol/vmtest/examples.test]
    ./simple_test.go:27:34: too few values in struct literal of type vmtest.QemuDisk